### PR TITLE
add default shop styles and required vars and mixins

### DIFF
--- a/boilerplate.scss
+++ b/boilerplate.scss
@@ -1,0 +1,22 @@
+
+// Variables
+@import "variables";
+
+// Mixins
+@import "mixins/headings";
+@import "mixins/media-query";
+
+// Toolkit Base
+@import "toolkit-base/border-box";
+@import "toolkit-base/clearfix";
+@import "toolkit-base/clearfix-legacy";
+@import "toolkit-base/fluid-media";
+
+// Toolkit Silent
+@import "toolkit-silent/mixin-font-size";
+
+// Shop
+@import "shop/category-layout";
+@import "shop/product-layout";
+@import "shop/product-summary";
+@import "shop/product-summary-tile-widths";

--- a/mixins/media-query.scss
+++ b/mixins/media-query.scss
@@ -1,0 +1,25 @@
+/* ============= //
+// MEDIA QUERIES //
+// ============= */
+
+// Stu Robson’s life changing IE fallback media query
+// https://github.com/sturobson/Sassifaction/blob/master/sass/base/mixins/_media-queries.scss
+// Added a -1px for max media query to work with inuit.css’s breakpoint variables – @TODO: make this work with variables only, so that arbitrary integers don’t get 1px removed
+// @TODO: document this a bit more
+@mixin mq($mbp, $min-max: min, $lt-ie9: false) {
+
+	@if $lt-ie9 == true {
+		.lt-ie9 & {
+			@content;
+		}
+	}
+
+	@if $min-max == max {
+		$mbp: $mbp - 1px;
+	}
+
+	@media only screen and (#{$min-max}-width:$mbp) {
+		@content;
+	}
+
+}

--- a/shop/category-layout.scss
+++ b/shop/category-layout.scss
@@ -1,0 +1,43 @@
+
+// These are included by default in the boilerplate setup but you can set this variable to 'false'.
+
+@if $shop-category-default-styles == true {
+
+	.product-summary-list--row {
+
+		// Reset user-agent list styles
+		margin-left: 0;
+		margin-bottom: 0;
+		padding-left: 0;
+		list-style: none;
+	}
+
+
+	.product-summary-list--tile {
+
+		.product-summary__image {
+
+			margin-bottom: ($base-spacing-unit/5)*2;
+		}
+
+		.product-summary__details__title {
+
+			// Break long titles
+			word-wrap: break-word;
+
+			@include font-size($base-font-size - 2px);
+			margin-bottom: ($base-spacing-unit/5)*2;
+		}
+
+		.product-summary__body {
+
+			// Add spacing to the anchor
+			margin-bottom: $base-spacing-unit;
+		}
+	}
+
+	// @TODO: Add the flexbox alignment CSS here
+	// @TODO: Add the mixin that creates all the grid widths at each breakpoint so that the user can select a grid size within the application
+
+
+} // end @if

--- a/shop/product-layout.scss
+++ b/shop/product-layout.scss
@@ -1,0 +1,118 @@
+
+// These used to be inline in the html, as of WDK version 1.2 you will need to include them in your own CSS or roll your own.
+// They are included by default in the boilerplate setup but you can set this variable to 'false'.
+
+@if $shop-product-default-styles == true {
+
+	// Product Layout 10
+	.product--image-narrow {
+
+		.product-item__gallery {
+			padding-right: 18px;
+		}
+		.product-item__details {
+			margin-top: 0;
+			margin-bottom: 2em;
+		}
+		.product-item__gallery {
+			border-right-style: solid;
+			border-right-width: 1px;
+		}
+		.product-item__gallery__image-list {
+			margin-bottom: 0;
+		}
+		.product-item__gallery__image-list,
+		.product-item__details {
+			padding-left: 0;
+			list-style: none;
+		}
+	}
+
+	// Product Layout 11
+	.product--image-wide {
+
+		.product-item__gallery__image-list,
+		.product-item__details {
+			padding-left: 0;
+			list-style: none;
+			margin-bottom: 2em;
+		}
+		.product-item__details {
+			margin-bottom: 0;
+		}
+		.product-item__details li:last-child {
+			margin-bottom: 0;
+		}
+		.wdk_product-basket-info {
+			text-align: right;
+		}
+	}
+
+	// Styles for both layout 10 and 11
+	.product h3 {
+		margin-top: 0;
+		font-size: 18px;
+		margin-bottom: 0;
+	}
+	.product-item__gallery__image-list {
+		margin-left: -0.5em;
+		text-align: center;
+	}
+	.product-item__gallery__image-main .product-item__gallery__image-wrapper {
+		display: table-cell;
+		vertical-align: middle;
+	}
+	.product-item__gallery__image-main .photo {
+		max-width: 100%;
+		max-height: 400px;
+		height: auto;
+	}
+	.product-item__details li {
+		margin-bottom: 1em;
+	}
+	.product-item__gallery__image-main {
+		margin-bottom: 2em;
+		min-height: 403px;
+		height: 403px;
+		display: table;
+		table-layout: fixed;
+		text-align: center;
+		width: 100%;
+		// Limit the longest size of the main image to 400px max and center
+		// Extra 3px prevents the content from bumping up and down when main image orientation changes. I know right‽
+		max-width: 403px;
+		margin-right: auto;
+		margin-left: auto;
+	}
+	.product-item__gallery__image-thumb {
+		min-height: 60px;
+		height: 60px;
+		max-height: 60px;
+		min-width: 60px;
+		width: 60px;
+		max-width: 60px;
+		position: relative;
+		margin-left: 0.5em;
+		margin-bottom: 0.5em;
+		display: inline-block;
+		zoom: 1;
+		*display: inline;
+		background-position: center center;
+		background-repeat: no-repeat;
+		-webkit-background-size: cover;
+		background-size: cover;
+		cursor: pointer;
+	}
+	.product-item__footer {
+		border-top-width: 1px;
+		border-top-style: solid;
+		padding-top: 12px;
+		margin-top: 12px;
+	}
+	.product-item__gallery__image-thumb > span {
+		 position: absolute;
+		 left: -9999em;
+		 font-size: -9999em;
+	}
+
+} // end @if

--- a/shop/product-summary-tile-widths.scss
+++ b/shop/product-summary-tile-widths.scss
@@ -1,0 +1,133 @@
+
+// Category Layouts Grid Sizes
+//
+// This Sass map is looped over in the below code in order to create the responsive width classes for the category tile layout.
+// The 4 sizes correspond to the 4 available in the application using the range slider.
+// Because this list is set as !default, it can be overwritten in each template setup.
+
+$cat-layout-lap: (
+	wdk_columnCount_0: (
+		xsmall: 33%,
+		small: 33%,
+		medium: 33%,
+		large: 50%
+	),
+	wdk_columnCount_1: (
+		xsmall: 33%,
+		small: 33%,
+		medium: 33%,
+		large: 50%
+	), 
+	wdk_columnCount_2: (
+		xsmall: 33%,
+		small: 33%,
+		medium: 50%,
+		large: 100%
+	), 
+) !default;
+
+$cat-layout-lap-mid: (
+	wdk_columnCount_0: (
+		xsmall: 25%,
+		small: 33%,
+		medium: 25%,
+		large: 33%
+	),
+	wdk_columnCount_1: (
+		xsmall: 25%,
+		small: 33%,
+		medium: 33%,
+		large: 50%
+	), 
+	wdk_columnCount_2: (
+		xsmall: 25%,
+		small: 33%,
+		medium: 50%,
+		large: 100%
+	), 
+) !default;
+
+$cat-layout-desk: (
+	wdk_columnCount_0: (
+		xsmall: 16.666%,
+		small: 20%,
+		medium: 25%,
+		large: 33%
+	),
+	wdk_columnCount_1: (
+		xsmall: 20% ,
+		small: 25%,
+		medium: 33%,
+		large: 50%
+	), 
+	wdk_columnCount_2: (
+		xsmall: 25%,
+		small: 33%,
+		medium: 50%,
+		large: 100%
+	), 
+) !default;
+
+
+
+// Mixin to create the classes using the above maps
+// @include category-layout--tile($cat-layout-lap, false, $lap-start);
+// Would give you every column count variation for the lap and up breakpoint.
+
+@mixin category-layout--tile($map-name, $ie-support: true, $breakpoint: not-set){
+
+	@if $breakpoint == not-set {
+
+		// First layer of the sass map
+		@each $column-count, $layout-sizes in $map-name {
+
+			// Create the .wdk_columnCount_x class
+			&.#{$column-count} {
+
+				// Third layer of the sass map
+				@each $layout-size, $width in $layout-sizes {
+					.product-summary-list--tile--#{$layout-size} .grid__item {
+						width: $width;
+					} 
+			
+				} 
+		
+			} // End the .wdk_columnCount_x class
+
+		} // End @each
+
+	} @else {
+
+		@include mq($breakpoint, min, $ie-support) {
+
+			// First layer of the sass map
+			@each $column-count, $layout-sizes in $map-name {
+
+				// Create the .wdk_columnCount_x class
+				&.#{$column-count} {
+
+					// Third layer of the sass map
+					@each $layout-size, $width in $layout-sizes {
+						.product-summary-list--tile--#{$layout-size} .grid__item {
+							width: $width;
+						} 
+				
+					} 
+			
+				} // End the .wdk_columnCount_x class
+
+			} // End @each
+
+		} // End Media query
+
+	} // end @else
+
+
+}
+
+
+body {
+	@include category-layout--tile($cat-layout-lap, false, $lap-start);
+	@include category-layout--tile($cat-layout-lap-mid, false, $lap-mid-start);
+	@include category-layout--tile($cat-layout-desk, true, $desk-start);
+}

--- a/shop/product-summary.scss
+++ b/shop/product-summary.scss
@@ -1,0 +1,45 @@
+@if $product-summary-default-styles == true {
+
+	.product-summary {
+
+		position: relative;
+	}
+	
+	// E: sale banner
+	.product-summary__sale-banner {
+		
+		position: absolute;
+		z-index: 10;
+	}
+
+	.product-summary__body {
+
+		// INFO: Extends the .link-complex inuit.css object, specifically assigned to an <a> element for more flexible RWD
+		// @TODO: work out how to do this without inuit.css
+		position: relative;
+		display: block;
+
+		// Extend the Clearfix
+		@extend .cf;
+
+	}
+
+	.product-summary__details {
+
+		// INFO: Extends the .multi-list inuit.css object, specifically assigned to an <ul> element
+		// @TODO: work out how to do this without inuit.css
+		margin-bottom: 0;
+		border-top: none;
+
+		// Reset list styles
+		list-style-type: none;
+		padding-left: 0;
+	}
+
+	// E: Quick-add-to-basket wrapper
+	.product-summary__add {
+
+		width: 100%;
+	}
+
+} // end @if

--- a/toolkit-base/clearfix.scss
+++ b/toolkit-base/clearfix.scss
@@ -10,7 +10,7 @@
 // Further Reading: http://nicolasgallagher.com/micro-clearfix-hack
 */
 
-
+.cf,
 .clearfix {
 
 	&:before,

--- a/variables.scss
+++ b/variables.scss
@@ -8,3 +8,19 @@
 
 
 $base-font-size: 16px!default;
+$base-line-height: 18px!default;
+$base-spacing-unit: 24px!default;
+
+
+// Breakpoints
+$lap-start:         481px!default;
+$desk-start:        1024px!default;
+$desk-wide-start:   1200px!default;
+$lap-mid-start: 	$desk-wide-start - $lap-start !default;
+
+// Default Shop Styles
+// These used to be inline in the html, as of WDK version 1.2 you will need to include them in your own CSS or roll your own
+
+$shop-product-default-styles: true!default;
+$shop-category-default-styles: true!default;
+$product-summary-default-styles: true!default;


### PR DESCRIPTION
First off I've created a `boilerplate.scss` file that imports all of the boilerplate Sass partials and means including the boilerplate is as simple as `@import "boilerplate"';`

I've also added a load of shop CSS, I've tried to make it as minimal as possible, resets and required styles only. Theres some variables that can be set to 'true' or 'false' depending on if you want this CSS or want to create your own - this may need some thought as I think I'm making required styling optional at the moment.

New (copied) Shop CSS
- Product Summary 
- Product Page - layout 10 + 11, taken from the inline style blocks on those template files.
- Category Layout base styles - taken from boilerplate v.1
- Category Layout grid sizes (all that CSS that allows the user to decide how big they want the grid items to be.)

In order for that to work I've also had to add...
- Media query mixin
- Breakpoint variables
- base sizing variables
### Related PR's

https://github.com/createdotnet/dyos_includes/pull/1033
https://github.com/createdotnet/dyos_templates/pull/71

Theres also a branch on dyos_html where I've created a new template if you'd like to check out to it and have a play around
### Staff to check

@benjaminparry 
