### PR TITLE
dropdown-inline-menu-length

### DIFF
--- a/mixins/navigation/_dropdown--inline.scss
+++ b/mixins/navigation/_dropdown--inline.scss
@@ -147,8 +147,10 @@
 
 	// Context: direct child of a sub category
 	.nav-main__item--has-sub > .nav-main__link {
+
+		// TODO extend the mixin to pass custom characters
 		&:after {
-			content: "\00a0\00bb";
+			content: "\00bb"; // encoded special character "»"
 
 		}
 	}


### PR DESCRIPTION
https://github.com/createdotnet/dyos_html/pull/1098

Removing the CSS encoded `&nbsp;` from the inline dropdown mixin.

Also adding a TODO to extend the mixin to add custom characters, I guess we should also make an option to ommit the character entirely. 
