### PR TITLE
Reduce amount of CSS files loaded

### DIFF
--- a/component/icon-fonts.scss
+++ b/component/icon-fonts.scss
@@ -4,11 +4,7 @@
 
 /*
 // Docs: https://github.com/createdotnet/development_resources/wiki/boilerplate#icon-fonts;
-//
-// @TODO: Automate concatenation and minification
 */
-
-
 
 /*
 // Shared styles for template icon fonts generated from https://icomoon.io
@@ -32,7 +28,7 @@
 
 /*
 // Icon Unicodes
-// 
+//
 // More info on private use unicode grid - http://www.fileformat.info/info/unicode/block/private_use_area/utf8test.htm
 */
 

--- a/component/icon-fonts.scss
+++ b/component/icon-fonts.scss
@@ -1,0 +1,104 @@
+/* ========== //
+// ICON FONTS //
+// ========== */
+
+/*
+// Docs: https://github.com/createdotnet/development_resources/wiki/boilerplate#icon-fonts;
+//
+// @TODO: Automate concatenation and minification
+*/
+
+
+
+/*
+// Shared styles for template icon fonts generated from https://icomoon.io
+*/
+
+.i {
+
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+
+    /* Better Font Rendering =========== */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+
+
+/*
+// Icon Unicodes
+// 
+// More info on private use unicode grid - http://www.fileformat.info/info/unicode/block/private_use_area/utf8test.htm
+*/
+
+.i-home:before {
+    content: "\e600";
+}
+.i-account:before {
+    content: "\e601";
+}
+.i-up:before {
+    content: "\e602";
+}
+.i-down:before {
+    content: "\e603";
+}
+.i-right--heavy:before {
+    content: "\e604";
+}
+.i-down--heavy:before {
+    content: "\e605";
+}
+.i-menu:before {
+    content: "\e606";
+}
+.i-search:before {
+    content: "\e607";
+}
+.i-basket:before {
+    content: "\e608";
+}
+.i-checkout:before {
+    content: "\e609";
+}
+.i-plus:before {
+    content: "\e60a";
+}
+.i-info:before {
+    content: "\e60b";
+}
+.i-rss:before {
+    content: "\e60c";
+}
+.i-youtube:before {
+    content: "\e60d";
+}
+.i-twitter:before {
+    content: "\e60e";
+}
+.i-facebook:before {
+    content: "\e60f";
+}
+.i-pinterest:before {
+    content: "\e610";
+}
+.i-instagram:before {
+    content: "\e611";
+}
+.i-linkedin:before {
+    content: "\e612";
+}
+.i-google-plus:before {
+    content: "\e613";
+}
+.i-left:before {
+    content: "\e614";
+}
+.i-right:before {
+    content: "\e615";
+}

--- a/template/index.html
+++ b/template/index.html
@@ -10,8 +10,6 @@
 <!--[if !IE]><!--> <html class="no-js not-ie"> <!--<![endif]-->
 	<head>
 
-		<!--WDK:base:js:modernizr-->
-
 		<!--WDK:comment: Force browser to render using Chrome Frame or latest IE rendering engine -->
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 		<!--WDK:comment: Viewport for mobile -->
@@ -21,13 +19,11 @@
 
 		<style>
 			<!--WDK:base:css:fonts-->
-			/* A comment to stop the syntax highlighting from breaking */
 			/* Add the template background options */
 			html { <!--WDK:templateoption:templatebg--> }
 		</style>
 
 		<!--WDK:base:css:grid:responsive-->
-		<!--WDK:base:css:icons-->
 
 		<!--WDK:comment: This script is the defacto way to enable use of HTML5 sectioning elements in legacy Internet Explorer ~ https://github.com/aFarkas/html5shiv -->
 		<!--WDK:comment: Positioned in head because rendering of icon fonts -->


### PR DESCRIPTION
In an attempt to reduce the amount of CSS files that are loaded on sites, I've moved the icon-font CSS into each template CSS file, getting it from here in the boilerplate.
