### PR TITLE
Pagebuilder image block scale

### DIFF
--- a/styles/component/pagebuilder/_content-block.scss
+++ b/styles/component/pagebuilder/_content-block.scss
@@ -211,6 +211,34 @@
 .content-block--image--portrait1x3 { padding-bottom: 300%; }
 
 
+.content-block--image--scale-10 {
+	transform: scale(0.1);
+}
+.content-block--image--scale-20 {
+	transform: scale(0.2);
+}
+.content-block--image--scale-30 {
+	transform: scale(0.3);
+}
+.content-block--image--scale-40 {
+	transform: scale(0.4);
+}
+.content-block--image--scale-50 {
+	transform: scale(0.5);
+}
+.content-block--image--scale-60 {
+	transform: scale(0.6);
+}
+.content-block--image--scale-70 {
+	transform: scale(0.7);
+}
+.content-block--image--scale-80 {
+	transform: scale(0.8);
+}
+.content-block--image--scale-90 {
+	transform: scale(0.9);
+}
+
 
 /*
 // Type: Text

--- a/styles/component/pagebuilder/_content-block.scss
+++ b/styles/component/pagebuilder/_content-block.scss
@@ -212,42 +212,45 @@
 
 
 // Image scale
-
-.content-block--image__scale-10 {
+.content-block--scale-10,
+.content-block--scale-20,
+.content-block--scale-30,
+.content-block--scale-40,
+.content-block--scale-50,
+.content-block--scale-60,
+.content-block--scale-70,
+.content-block--scale-80,
+.content-block--scale-90 {
+	> div {
+		margin: 0 auto;
+	}
+}
+.content-block--scale-10 > div {
 	width: 10%;
-	margin: 0 auto;
 }
-.content-block--image__scale-20 {
+.content-block--scale-20 > div {
 	width: 20%;
-	margin: 0 auto;
 }
-.content-block--image__scale-30 {
+.content-block--scale-30 > div {
 	width: 30%;
-	margin: 0 auto;
 }
-.content-block--image__scale-40 {
+.content-block--scale-40 > div {
 	width: 40%;
-	margin: 0 auto;
 }
-.content-block--image__scale-50 {
+.content-block--scale-50 > div {
 	width: 50%;
-	margin: 0 auto;
 }
-.content-block--image__scale-60 {
+.content-block--scale-60 > div {
 	width: 60%;
-	margin: 0 auto;
 }
-.content-block--image__scale-70 {
+.content-block--scale-70 > div {
 	width: 70%;
-	margin: 0 auto;
 }
-.content-block--image__scale-80 {
+.content-block--scale-80 > div {
 	width: 80%;
-	margin: 0 auto;
 }
-.content-block--image__scale-90 {
+.content-block--scale-90 > div {
 	width: 90%;
-	margin: 0 auto;
 }
 
 

--- a/styles/component/pagebuilder/_content-block.scss
+++ b/styles/component/pagebuilder/_content-block.scss
@@ -213,32 +213,41 @@
 
 // Image scale
 
-.content-block--image--scale-10 {
-	transform: scale(0.1);
+.content-block--image__scale-10 {
+	width: 10%;
+	margin: 0 auto;
 }
-.content-block--image--scale-20 {
-	transform: scale(0.2);
+.content-block--image__scale-20 {
+	width: 20%;
+	margin: 0 auto;
 }
-.content-block--image--scale-30 {
-	transform: scale(0.3);
+.content-block--image__scale-30 {
+	width: 30%;
+	margin: 0 auto;
 }
-.content-block--image--scale-40 {
-	transform: scale(0.4);
+.content-block--image__scale-40 {
+	width: 40%;
+	margin: 0 auto;
 }
-.content-block--image--scale-50 {
-	transform: scale(0.5);
+.content-block--image__scale-50 {
+	width: 50%;
+	margin: 0 auto;
 }
-.content-block--image--scale-60 {
-	transform: scale(0.6);
+.content-block--image__scale-60 {
+	width: 60%;
+	margin: 0 auto;
 }
-.content-block--image--scale-70 {
-	transform: scale(0.7);
+.content-block--image__scale-70 {
+	width: 70%;
+	margin: 0 auto;
 }
-.content-block--image--scale-80 {
-	transform: scale(0.8);
+.content-block--image__scale-80 {
+	width: 80%;
+	margin: 0 auto;
 }
-.content-block--image--scale-90 {
-	transform: scale(0.9);
+.content-block--image__scale-90 {
+	width: 90%;
+	margin: 0 auto;
 }
 
 

--- a/styles/component/pagebuilder/_content-block.scss
+++ b/styles/component/pagebuilder/_content-block.scss
@@ -211,6 +211,8 @@
 .content-block--image--portrait1x3 { padding-bottom: 300%; }
 
 
+// Image scale
+
 .content-block--image--scale-10 {
 	transform: scale(0.1);
 }


### PR DESCRIPTION
A new option on the 'image' content block, to scale the image down, just like you can on 'image and text'.